### PR TITLE
Fix Tuist installation in CI workflows

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -13,7 +13,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Tuist
-        run: curl -Ls https://tuist.io/install.sh | bash
+        run: |
+          brew tap tuist/tuist
+          brew install --formula tuist
 
       - name: Generate project
         run: tuist generate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Tuist
-        run: curl -Ls https://tuist.io/install.sh | bash
+        run: |
+          brew tap tuist/tuist
+          brew install --formula tuist
 
       - name: Generate project
         run: tuist generate


### PR DESCRIPTION
## Summary
- replace the curl-based Tuist installation script with Homebrew commands so CI runners can install the CLI without hitting the login-protected tuist.io script

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d078ca0d9c832d89975d0284dc1d6c